### PR TITLE
Add options "reindent_on_save" and "opam_switch"

### DIFF
--- a/OcpIndent.sublime-settings
+++ b/OcpIndent.sublime-settings
@@ -1,3 +1,5 @@
 {
-	"reindent_on_tab": true
+	"reindent_on_tab": true,
+	"reindent_on_save": true,
+	"opam_switch":"system",
 }

--- a/OcpIndent.sublime-settings
+++ b/OcpIndent.sublime-settings
@@ -1,5 +1,5 @@
 {
 	"reindent_on_tab": true,
 	"reindent_on_save": true,
-	"opam_switch":"system",
+	"opam_switch":null,
 }

--- a/sublime-text-ocp-indent.py
+++ b/sublime-text-ocp-indent.py
@@ -13,8 +13,12 @@ import subprocess
 
 def plugin_loaded():
 	global reindent_on_tab
+	global reindent_on_save
+	global opam_switch
 	settings = sublime.load_settings("OcpIndent.sublime-settings")
 	reindent_on_tab = settings.get("reindent_on_tab")
+	reindent_on_save = settings.get("reindent_on_save")
+	opam_switch = settings.get("opam_switch")
 
 def is_ocaml(view):
 	return view.match_selector(view.sel()[0].begin(), "source.ocaml")
@@ -22,6 +26,8 @@ def is_ocaml(view):
 def indent_lines(view, edit, lines, indent_empty = True):
 	if not is_ocaml(view):
 		return
+
+	global opam_switch
 
 	command = ["ocp-indent", "--numeric"]
 
@@ -34,7 +40,8 @@ def indent_lines(view, edit, lines, indent_empty = True):
 		stdin = subprocess.PIPE,
 		stdout = subprocess.PIPE,
 		stderr = subprocess.PIPE,
-		universal_newlines = True
+		universal_newlines = True,
+		env = {"PATH":os.getenv("HOME")+"/.opam/"+opam_switch+"/bin/"}
 	)
 
 	content = view.substr(sublime.Region(0, view.size()))
@@ -82,7 +89,8 @@ class OcpIndentEventListener(sublime_plugin.EventListener):
 	waiting_for_modify = False
 
 	def on_pre_save(self, view):
-		if is_ocaml(view):
+		global reindent_on_save
+		if is_ocaml(view) and reindent_on_save:
 			view.run_command("ocp_indent_file", { "indent_empty": False })
 
 	def on_modified(self, view):

--- a/sublime-text-ocp-indent.py
+++ b/sublime-text-ocp-indent.py
@@ -35,13 +35,20 @@ def indent_lines(view, edit, lines, indent_empty = True):
 		command.append("--indent-empty")
 
 	# get the proper indentation from ocp-indent
+	cmd_env = os.environ.copy()
+
+	if opam_switch is not None:
+		cmd_env["PATH"] = \
+			os.path.join(cmd_env["HOME"], ".opam", opam_switch, "bin") + \
+			os.pathsep + cmd_env["PATH"]
+
 	process = subprocess.Popen(
 		command,
 		stdin = subprocess.PIPE,
 		stdout = subprocess.PIPE,
 		stderr = subprocess.PIPE,
 		universal_newlines = True,
-		env = {"PATH":os.getenv("HOME")+"/.opam/"+opam_switch+"/bin/"}
+		env = cmd_env
 	)
 
 	content = view.substr(sublime.Region(0, view.size()))


### PR DESCRIPTION
Hi! First, thanks for developing the plugin, it was much needed and is very appreciated. 

I suggest adding a few options in the settings file:

- `reindent_on_save` enables deactivating automatic reindent, it might be useful when committing on large files;
- `opam_switch` enables using other opam switches than the default one (just enter the version, e.g. "4.04.1"); in particular, on UNIX, this enables using the config file `$HOME/.ocp/.ocp-indent.conf`. This was indispensable in my job, where we make extensive use of `lwt` (camlp4-like) syntax.